### PR TITLE
Neptune单词拼写错误修正

### DIFF
--- a/source/chapter2/08_Enumerations.md
+++ b/source/chapter2/08_Enumerations.md
@@ -52,7 +52,7 @@ enum CompassPoint {
 
 ```swift
 enum Planet {
-  case Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Nepturn
+  case Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune
 }
 ```
 


### PR DESCRIPTION
Neptune海王星 错写成了Nepturn
