### PR TITLE
42195.0米

### DIFF
--- a/source/chapter2/20_Extensions.md
+++ b/source/chapter2/20_Extensions.md
@@ -81,7 +81,7 @@ println("Three feet is \(threeFeet) meters")
 ```swift
 let aMarathon = 42.km + 195.m
 println("A marathon is \(aMarathon) meters long")
-// 打印输出："A marathon is 42495.0 meters long"
+// 打印输出："A marathon is 42195.0 meters long"
 ```
 
 


### PR DESCRIPTION
马拉松的长度是42195，代码错写成了42495。特此更正。
