### PR TITLE
Update 21_Protocols.md

### DIFF
--- a/source/chapter2/21_Protocols.md
+++ b/source/chapter2/21_Protocols.md
@@ -95,7 +95,7 @@ var ncc1701 = Starship(name: "Enterprise", prefix: "USS")
 // ncc1701.fullName 为 "USS Enterprise"
 ```
 
-`Starship` 类只能把 `fullName` 作为只读的计算属性来实现。每一个 `Starship` 类的实例都有一个名为 `name` 的非可选属性和一个名为 `prefix` 的可选属性。 当 `prefix` 存在时，计算属性 `fullName` 会将 `prefix` 插入到 `name` 之前，从而得到一个带有 `prefix` 的 `fullName`。
+`Starship` 类把 `fullName` 作为只读的计算属性来实现。每一个 `Starship` 类的实例都有一个名为 `name` 的非可选属性和一个名为 `prefix` 的可选属性。 当 `prefix` 存在时，计算属性 `fullName` 会将 `prefix` 插入到 `name` 之前，从而得到一个带有 `prefix` 的 `fullName`。
 
 ## 方法要求 {#method-requirements}
 


### PR DESCRIPTION
协议的只读属性要求，实现时该属性可以只读，也可以读写。

原文：
This class implements the fullName property requirement as a computed read-only property for a starship. 

所以此处去掉“只能”二字。