### PR TITLE
修复运算符声明文档错误

### DIFF
--- a/source/03_language_reference/06_Declarations.md
+++ b/source/03_language_reference/06_Declarations.md
@@ -1630,7 +1630,7 @@ infix operator 运算符名称: 优先级组
 下面的形式声明了一个新的前缀运算符：
 
 ```swift
-prefix operator 运算符名称 {}
+prefix operator 运算符名称
 ```
 
 出现在运算对象前边的前缀运算符是一元运算符，例如表达式 `!a` 中的前缀非运算符（`!`）。
@@ -1640,7 +1640,7 @@ prefix operator 运算符名称 {}
 下面的形式声明了一个新的后缀运算符：
 
 ```swift
-postfix operator 运算符名称 {}
+postfix operator 运算符名称
 ```
 
 紧跟在运算对象后边的后缀运算符是一元运算符，例如表达式 `a!` 中的后缀强制解包运算符（`!`）。
@@ -1669,7 +1669,7 @@ postfix operator 运算符名称 {}
 > 
 ####  infix-operator-declaration {#infix-operator-declaration}
 > 
-> *中缀运算符声明* → **infix** **运算符** [运算符](./02_Lexical_Structure.md#operator) **{** [中缀运算符属性](#infix-operator-attributes)<sub>可选</sub> **}**
+> *中缀运算符声明* → **infix** **运算符** [运算符](./02_Lexical_Structure.md#operator) **{** [中缀运算符组](#infix-operator-attributes)<sub>可选</sub> **}**
 > 
 
 #### infix-operator-group {#infix-operator-group}

--- a/source/03_language_reference/06_Declarations.md
+++ b/source/03_language_reference/06_Declarations.md
@@ -1669,8 +1669,7 @@ postfix operator 运算符名称
 > 
 ####  infix-operator-declaration {#infix-operator-declaration}
 > 
-> *中缀运算符声明* → **infix** **运算符** [运算符](./02_Lexical_Structure.md#operator) **{** [中缀运算符组](#infix-operator-attributes)<sub>可选</sub> **}**
-> 
+> *中缀运算符声明* → **infix** **运算符** [运算符](./02_Lexical_Structure.md#operator) **{** [中缀运算符组](#infix-operator-group)<sub>可选</sub> **}**
 
 #### infix-operator-group {#infix-operator-group}
 > *中缀运算符组* → [优先级组名称](#precedence-group-name)


### PR DESCRIPTION
根据官方文档，运算符声明时没有"{}"
https://docs.swift.org/swift-book/ReferenceManual/Declarations.html#ID380