### PR TITLE
修改下标章节和继承章节

### DIFF
--- a/source/02_language_guide/12_Subscripts.md
+++ b/source/02_language_guide/12_Subscripts.md
@@ -115,7 +115,7 @@ var matrix = Matrix(rows: 2, columns: 2)
 
 上例中创建了一个两行两列的 `Matrix` 实例。该 `Matrix` 实例的 `grid` 数组按照从左上到右下的阅读顺序将矩阵扁平化存储：
 
-![](https://docs.swift.org/swift-book/_images/subscriptMatrix01_2x.png)
+![](https://docs.swift.org/swift-book/images/subscriptMatrix01@2x.png)
 
 将 `row` 和 `column` 的值传入下标来为矩阵设值，下标的入参使用逗号分隔：
 
@@ -126,7 +126,7 @@ matrix[1, 0] = 3.2
 
 上面两条语句分别调用下标的 setter 将矩阵右上角位置（即 `row` 为 `0`、`column` 为 `1` 的位置）的值设置为 `1.5`，将矩阵左下角位置（即 `row` 为 `1`、`column` 为 `0` 的位置）的值设置为 `3.2`：
 
-![](https://docs.swift.org/swift-book/_images/subscriptMatrix02_2x.png)
+![](https://docs.swift.org/swift-book/images/subscriptMatrix02@2x.png)
 
 `Matrix` 下标的 getter 和 setter 中都含有断言，用来检查下标入参 `row` 和 `column` 的值是否有效。为了方便进行断言，`Matrix` 包含了一个名为 `indexIsValid(row:column:)` 的便利方法，用来检查入参 `row` 和 `column` 的值是否在矩阵范围内：
 
@@ -143,7 +143,7 @@ let someValue = matrix[2, 2]
 // 断言将会触发，因为 [2, 2] 已经超过了 matrix 的范围
 ```
 
-## 类型下标{#type-subscripts}
+## 类型下标 {#type-subscripts}
 正如上节所述，实例下标是在特定类型的一个实例上调用的下标。你也可以定义一种在这个类型自身上调用的下标。这种下标被称作_类型下标_。你可以通过在 `subscript` 关键字之前写下 `static` 关键字的方式来表示一个类型下标。类型可以使用 `class` 关键字来代替 `static`，它允许子类重写父类中对那个下标的实现。下面的例子展示了如何定义和调用一个类型下标：
 ```
 enum Planet: Int {

--- a/source/02_language_guide/13_Inheritance.md
+++ b/source/02_language_guide/13_Inheritance.md
@@ -69,7 +69,7 @@ class Bicycle: Vehicle {
 
 除了所继承的特性，`Bicycle` 类还定义了一个默认值为 `false` 的存储型属性 `hasBasket`（属性推断为 `Bool`）。
 
-默认情况下，你创建的所有新的 `Bicycle` 实例不会有一个篮子（即 `hasBasket` 属性默认为 `false`）。创建该实例之后，你可以为 `Bicycle` 实例设置 `hasBasket` 属性为 `ture`：
+默认情况下，你创建的所有新的 `Bicycle` 实例不会有一个篮子（即 `hasBasket` 属性默认为 `false`）。创建该实例之后，你可以为 `Bicycle` 实例设置 `hasBasket` 属性为 `true`：
 
 ```swift
 let bicycle = Bicycle()
@@ -216,6 +216,6 @@ print("AutomaticCar: \(automatic.description)")
 
 你可以通过把方法，属性或下标标记为 *`final`* 来防止它们被重写，只需要在声明关键字前加上 `final` 修饰符即可（例如：`final var`、`final func`、`final class func` 以及 `final subscript`）。
 
-任何试图对带有 `final` 标记的方法、属性或下标进行重写的代码，都会在编译时会报错。在类扩展中的方法，属性或下标也可以在扩展的定义里标记为 `final`。
+任何试图对带有 `final` 标记的方法、属性或下标进行重写的代码，都会在编译时报错。在类扩展中的方法，属性或下标也可以在扩展的定义里标记为 `final`。
 
 可以通过在关键字 `class` 前添加 `final` 修饰符（`final class`）来将整个类标记为 final 。这样的类是不可被继承的，试图继承这样的类会导致编译报错。


### PR DESCRIPTION
修复下标章节的图片链接与标题
修改继承章节的错别字