### PR TITLE
修复：纠正 MemorySafety.md 中的翻译错误问题

### DIFF
--- a/swift-6.docc/LanguageGuide/MemorySafety.md
+++ b/swift-6.docc/LanguageGuide/MemorySafety.md
@@ -156,7 +156,7 @@ increment(&stepSize)
   ```
 -->
 
-在上面的代码里，`stepSize` 是一个全局变量，并且它可以通常可以在 `increment(_:)` 里被访问。然而，对于 `stepSize` 的读访问与 `number` 的写访问重叠了。就像下面展示的那样，`number` 和 `stepSize` 都指向了同一个内存区域。针对同一块内存区域的读和写访问重叠了，因此产生了冲突。
+在上面的代码里，`stepSize` 是一个全局变量，并且它通常可以在 `increment(_:)` 里被访问。然而，对于 `stepSize` 的读访问与 `number` 的写访问重叠了。就像下面展示的那样，`number` 和 `stepSize` 都指向了同一个内存区域。针对同一块内存区域的读和写访问重叠了，因此产生了冲突。
 
 ![](memory_increment)
 


### PR DESCRIPTION
纠正了在 [MemorySafety.md](https://github.com/SwiftGGTeam/the-swift-programming-language-in-chinese/blob/main/swift-6.docc/LanguageGuide/MemorySafety.md) 文件中 [对 In-Out 参数的访问冲突](https://github.com/SwiftGGTeam/the-swift-programming-language-in-chinese/blob/main/swift-6.docc/LanguageGuide/MemorySafety.md#对-in-out-参数的访问冲突) 章节的翻译问题。

另外，这些修改是需要提交到 swift-6-beta-translation 分支吗？
